### PR TITLE
Add two new functions, CallRaw and CallInto

### DIFF
--- a/apiClient.go
+++ b/apiClient.go
@@ -92,7 +92,7 @@ func (client *Client) Call(method string, params interface{}) (interface{}, erro
 
 // CallInto is like call, but instead of returning an interface you pass it a
 // struct which is filled, much like the json.Unmarshal function.  The struct
-// you pass must statisfy the LWAPIRes interface.  If you embed the LWAPIError
+// you pass must satisfy the LWAPIRes interface.  If you embed the LWAPIError
 // struct from this package into your struct, this will be taken care of for you.
 //
 // Example:

--- a/examples/main.go
+++ b/examples/main.go
@@ -1,10 +1,23 @@
 package main
 
 import (
-	"github.com/spf13/viper"
 	"fmt"
 	lwInternalApi "github.com/liquidweb/go-lwInternalApi"
+	"github.com/spf13/viper"
 )
+
+type ZoneDetails struct {
+	lwInternalApi.LWAPIError
+	AvlZone     string   `json:"availability_zone"`
+	Desc        string   `json:"description"`
+	GatewayDevs []string `json:"gateway_devices"`
+	HvType      string   `json:"hv_type"`
+	ID          int      `json:"id"`
+	Legacy      int      `json:"legacy"`
+	Name        string   `json:"name"`
+	Status      string   `json:"status"`
+	SourceHVs   []string `json:"valid_source_hvs"`
+}
 
 func main() {
 	config := viper.New()
@@ -20,11 +33,22 @@ func main() {
 		panic(iErr)
 	}
 	args := map[string]interface{}{
-		"uniq_id": "2UPHPL",
+		"uniq_id": "SJ9NG6",
 	}
 	got, gotErr := apiClient.Call("bleed/asset/details", args)
 	if gotErr != nil {
 		panic(gotErr)
 	}
+
 	fmt.Printf("RETURNED:\n\n%+v\n\n", got)
+
+	var zone ZoneDetails
+	zArgs := map[string]interface{}{
+		"id": 1,
+	}
+	err := apiClient.CallInto("network/zone/details", zArgs, &zone)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Got struct %#v\n", zone)
 }


### PR DESCRIPTION
CallRaw returns the json blob as a byte slice without processing.
CallInto allows the caller to define custom structs for api calls.