### PR TITLE
remove dependency on viper for using api client

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ LiquidWeb API Golang client
 https://godoc.org/github.com/liquidweb/go-lwApi
 
 ## Setting up Authentication
-When creating an api client, it expects to be configured with a viper config. Here is an example of how to get an api client.
+When creating an api client, it expects to be configured via a configuration struct. Here is an example of how to get an api client.
 
 ```
 package main
@@ -13,35 +13,16 @@ import (
 	"fmt"
 
 	lwApi "github.com/liquidweb/go-lwApi"
-	"github.com/spf13/viper"
 )
 
 func main() {
-	config := viper.New()
-	config.SetConfigName("lwApi")
-	config.AddConfigPath(".")
-	// Match environment variables as well
-	config.AutomaticEnv()
-
-	viperErr := config.ReadInConfig()
-	if viperErr != nil {
-		panic(viperErr)
+	config := lwApi.LWAPIConfig{
+		Username: "ExampleUsername",
+		Password: "ExamplePassword",
+		Url:      "api.liquidweb.com",
 	}
-
-	config.Debug()
-
-	apiClient, iErr := lwApi.New(config)
+	apiClient, iErr := lwApi.New(&config)
 }
-```
-
-In this scenario, we rely on a configuration file in the current working directory named lwApi.{toml,yaml,json} to set up a viper client.
-This file might look like the following example:
-``` toml
-[lwApi]
-username = "SUPERDUPERUSER"
-password = "SUPERDUPERPW"
-url = "https://api.stormondemand.com"
-timeout = 15
 ```
 ## Importing
 ``` go
@@ -51,7 +32,7 @@ import (
 ```
 ## Calling a method
 ``` go
-apiClient, iErr := lwApi.New(config)
+apiClient, iErr := lwApi.New(&config)
 if iErr != nil {
   panic(iErr)
 }

--- a/_examples/main.go
+++ b/_examples/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	lwApi "github.com/liquidweb/go-lwApi"
-	"github.com/spf13/viper"
 )
 
 type ZoneDetails struct {
@@ -21,20 +20,12 @@ type ZoneDetails struct {
 }
 
 func main() {
-	config := viper.New()
-	config.SetConfigName("lwApi")
-	config.AddConfigPath(".")
-	// Match environment variables as well
-	config.AutomaticEnv()
-
-	viperErr := config.ReadInConfig()
-	if viperErr != nil {
-		panic(viperErr)
+	config := lwApi.LWAPIConfig{
+		Username: "ExampleUsername",
+		Password: "ExamplePassword",
+		Url:      "api.liquidweb.com",
 	}
-
-	config.Debug()
-
-	apiClient, iErr := lwApi.New(config)
+	apiClient, iErr := lwApi.New(&config)
 	if iErr != nil {
 		panic(iErr)
 	}

--- a/apiClient.go
+++ b/apiClient.go
@@ -21,7 +21,8 @@ import (
 	"time"
 )
 
-// A LWAPIConfig holds the
+// A LWAPIConfig holds the configuration details used to call
+// the API with the client.
 type LWAPIConfig struct {
 	Username string
 	Password string

--- a/apiClient.go
+++ b/apiClient.go
@@ -239,10 +239,10 @@ func processConfig(config *LWAPIConfig) error {
 		return fmt.Errorf("username is missing from config")
 	}
 	if config.Password == "" {
-		return fmt.Errorf("password is missing from config file")
+		return fmt.Errorf("password is missing from config")
 	}
 	if config.Url == "" {
-		return fmt.Errorf("url is missing from config file")
+		return fmt.Errorf("url is missing from config")
 	}
 	if config.Timeout == 0 {
 		config.Timeout = 20

--- a/apiClient.go
+++ b/apiClient.go
@@ -65,7 +65,7 @@ type LWAPIRes interface {
 
 // New takes a *LWAPIConfig, and gives you a *Client. If there's an error, it is returned.
 // When using this package, this should be the first function you call. Below is an example
-// that demonstrates creating the *viper.Viper and passing it to New.
+// that demonstrates creating the config and passing it to New.
 //
 // Example:
 //	config := LWAPIConfig{

--- a/apiClient.go
+++ b/apiClient.go
@@ -28,7 +28,7 @@ type LWAPIConfig struct {
 	Password string
 	Url      string
 	Timeout  uint
-	Secure   bool
+	Insecure bool
 }
 
 // A Client holds the packages *LWAPIConfig and *http.Client. To get a *Client, call New.
@@ -84,7 +84,7 @@ func New(config *LWAPIConfig) (*Client, error) {
 
 	httpClient := &http.Client{Timeout: time.Duration(time.Duration(config.Timeout) * time.Second)}
 
-	if config.Secure != true {
+	if config.Insecure {
 		tr := &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}


### PR DESCRIPTION
Forcing the api client to have a dependency on viper limits the utility of the library in a wider context.
Instead, we add support for a general config struct to be passed to new, allowing users to use the config system of their choosing.