### PR TITLE
allow api client to make use of oauth2 bearer tokens

### DIFF
--- a/_examples/main.go
+++ b/_examples/main.go
@@ -20,9 +20,12 @@ type ZoneDetails struct {
 }
 
 func main() {
+	username := "ExampleUsername"
+	password := "ExamplePassword"
+
 	config := lwApi.LWAPIConfig{
-		Username: "ExampleUsername",
-		Password: "ExamplePassword",
+		Username: &username,
+		Password: &password,
 		Url:      "api.liquidweb.com",
 	}
 	apiClient, iErr := lwApi.New(&config)


### PR DESCRIPTION
Add the ability for the api client to make use of Oauth2 bearer tokens, for compatibility with new oauth2 authentication capabilities.

For backwards compatibility, basic auth is still supported, but the format of the api config needs to change to allow them to not be passed in.